### PR TITLE
feat(go_on_provided): use -tags lambda.norpc build tag

### DIFF
--- a/s3-uploader/runtimes/go_on_provided/Dockerfile
+++ b/s3-uploader/runtimes/go_on_provided/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /tmpBuild
 COPY main.go .
 COPY go.mod .
 COPY go.sum .
-RUN go build -ldflags="-w -s" -o /tmp/bootstrap
+RUN go build -ldflags="-w -s" -tags lambda.norpc -o /tmp/bootstrap
 RUN zip -j /tmp/code.zip /tmp/bootstrap
 
 FROM scratch


### PR DESCRIPTION
Go on the Provided AL2 system doesn't require the RPC code that's in the Lambda SDK.

The aws-lambda-go library supports a build tag that strips this unused code from the package with the aim of improving cold start performance, since the unused code strips around 2MB from the output binary.
