### PR TITLE
update java8, 11, 17 + snapstart to remove runtime

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -75,14 +75,14 @@
     {
       "displayName": "java11",
       "runtime": "java11",
-      "handler": "io.github.maxday.Handler",
+      "handler": "io.github.maxday.Handler::handleRequest",
       "path": "java11",
       "architectures": ["x86_64", "arm64"]
     },
     {
       "displayName": "java8",
       "runtime": "java8.al2",
-      "handler": "io.github.maxday.Handler",
+      "handler": "io.github.maxday.Handler::handleRequest",
       "path": "java8",
       "architectures": ["x86_64", "arm64"]
     },
@@ -124,7 +124,7 @@
     {
       "displayName": "java11 snapstart",
       "runtime": "java11",
-      "handler": "io.github.maxday.Handler",
+      "handler": "io.github.maxday.Handler::handleRequest",
       "path": "java11_snapstart",
       "snapStart": {
         "SnapStart": {
@@ -143,7 +143,7 @@
     {
       "displayName": "java17 snapstart",
       "runtime": "java17",
-      "handler": "io.github.maxday.Handler",
+      "handler": "io.github.maxday.Handler::handleRequest",
       "path": "java17_snapstart",
       "snapStart": {
         "SnapStart": {

--- a/s3-uploader/runtimes/java11/build.gradle
+++ b/s3-uploader/runtimes/java11/build.gradle
@@ -7,19 +7,10 @@ repositories {
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
-dependencies {
-    implementation (
-        'com.amazonaws:aws-lambda-java-core:1.2.2',
-    )
-}
-
 task buildZip(type: Zip) {
     baseName = "code"
     from compileJava
     from processResources
-    into('lib') {
-        from configurations.runtimeClasspath
-    }
 }
 
 build.dependsOn buildZip

--- a/s3-uploader/runtimes/java11/src/main/java/io/github/maxday/Handler.java
+++ b/s3-uploader/runtimes/java11/src/main/java/io/github/maxday/Handler.java
@@ -1,12 +1,18 @@
 package io.github.maxday;
 
-import com.amazonaws.services.lambda.runtime.Context;
-import com.amazonaws.services.lambda.runtime.RequestHandler;
+import java.io.InputStream;
+import java.io.IOException;
+import java.io.OutputStream;
 
-public class Handler implements RequestHandler<Object, String> {
+public class Handler {
 
-    @Override
-    public String handleRequest(Object request, Context context) {
-        return "ok";
+    public void handleRequest(InputStream inputStream, OutputStream outputStream) throws IOException {
+        try {
+            outputStream.write("ok".getBytes());
+        } catch (IOException e) {
+            e.printStackTrace();
+        } finally {
+            outputStream.close();
+        }
     }
 }

--- a/s3-uploader/runtimes/java11_snapstart/build.gradle
+++ b/s3-uploader/runtimes/java11_snapstart/build.gradle
@@ -7,19 +7,10 @@ repositories {
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
-dependencies {
-    implementation (
-        'com.amazonaws:aws-lambda-java-core:1.2.2',
-    )
-}
-
 task buildZip(type: Zip) {
     baseName = "code"
     from compileJava
     from processResources
-    into('lib') {
-        from configurations.runtimeClasspath
-    }
 }
 
 build.dependsOn buildZip

--- a/s3-uploader/runtimes/java11_snapstart/src/main/java/io/github/maxday/Handler.java
+++ b/s3-uploader/runtimes/java11_snapstart/src/main/java/io/github/maxday/Handler.java
@@ -1,12 +1,18 @@
 package io.github.maxday;
 
-import com.amazonaws.services.lambda.runtime.Context;
-import com.amazonaws.services.lambda.runtime.RequestHandler;
+import java.io.InputStream;
+import java.io.IOException;
+import java.io.OutputStream;
 
-public class Handler implements RequestHandler<Object, String> {
+public class Handler {
 
-    @Override
-    public String handleRequest(Object request, Context context) {
-        return "ok";
+    public void handleRequest(InputStream inputStream, OutputStream outputStream) throws IOException {
+        try {
+            outputStream.write("ok".getBytes());
+        } catch (IOException e) {
+            e.printStackTrace();
+        } finally {
+            outputStream.close();
+        }
     }
 }

--- a/s3-uploader/runtimes/java17/src/main/java/io/github/maxday/Handler.java
+++ b/s3-uploader/runtimes/java17/src/main/java/io/github/maxday/Handler.java
@@ -1,11 +1,18 @@
 package io.github.maxday;
 
 import java.io.InputStream;
+import java.io.IOException;
 import java.io.OutputStream;
 
 public class Handler {
 
-    public String handleRequest(InputStream inputStream, OutputStream outputStream) {
-        return "ok";
+    public void handleRequest(InputStream inputStream, OutputStream outputStream) throws IOException {
+        try {
+            outputStream.write("ok".getBytes());
+        } catch (IOException e) {
+            e.printStackTrace();
+        } finally {
+            outputStream.close();
+        }
     }
 }

--- a/s3-uploader/runtimes/java17_snapstart/build.gradle
+++ b/s3-uploader/runtimes/java17_snapstart/build.gradle
@@ -7,19 +7,10 @@ repositories {
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
-dependencies {
-    implementation (
-        'com.amazonaws:aws-lambda-java-core:1.2.2',
-    )
-}
-
 task buildZip(type: Zip) {
     baseName = "code"
     from compileJava
     from processResources
-    into('lib') {
-        from configurations.runtimeClasspath
-    }
 }
 
 build.dependsOn buildZip

--- a/s3-uploader/runtimes/java17_snapstart/src/main/java/io/github/maxday/Handler.java
+++ b/s3-uploader/runtimes/java17_snapstart/src/main/java/io/github/maxday/Handler.java
@@ -1,12 +1,18 @@
 package io.github.maxday;
 
-import com.amazonaws.services.lambda.runtime.Context;
-import com.amazonaws.services.lambda.runtime.RequestHandler;
+import java.io.InputStream;
+import java.io.IOException;
+import java.io.OutputStream;
 
-public class Handler implements RequestHandler<Object, String> {
+public class Handler {
 
-    @Override
-    public String handleRequest(Object request, Context context) {
-        return "ok";
+    public void handleRequest(InputStream inputStream, OutputStream outputStream) throws IOException {
+        try {
+            outputStream.write("ok".getBytes());
+        } catch (IOException e) {
+            e.printStackTrace();
+        } finally {
+            outputStream.close();
+        }
     }
 }

--- a/s3-uploader/runtimes/java8/build.gradle
+++ b/s3-uploader/runtimes/java8/build.gradle
@@ -7,19 +7,10 @@ repositories {
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
-dependencies {
-    implementation (
-        'com.amazonaws:aws-lambda-java-core:1.2.2',
-    )
-}
-
 task buildZip(type: Zip) {
     baseName = "code"
     from compileJava
     from processResources
-    into('lib') {
-        from configurations.runtimeClasspath
-    }
 }
 
 build.dependsOn buildZip

--- a/s3-uploader/runtimes/java8/src/main/java/io/github/maxday/Handler.java
+++ b/s3-uploader/runtimes/java8/src/main/java/io/github/maxday/Handler.java
@@ -1,12 +1,18 @@
 package io.github.maxday;
 
-import com.amazonaws.services.lambda.runtime.Context;
-import com.amazonaws.services.lambda.runtime.RequestHandler;
+import java.io.InputStream;
+import java.io.IOException;
+import java.io.OutputStream;
 
-public class Handler implements RequestHandler<Object, String> {
+public class Handler {
 
-    @Override
-    public String handleRequest(Object request, Context context) {
-        return "ok";
+    public void handleRequest(InputStream inputStream, OutputStream outputStream) throws IOException {
+        try {
+            outputStream.write("ok".getBytes());
+        } catch (IOException e) {
+            e.printStackTrace();
+        } finally {
+            outputStream.close();
+        }
     }
 }


### PR DESCRIPTION
This PR extends https://github.com/maxday/lambda-perf/pull/410 to all other java functions