### PR TITLE
Add support for Python 3.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ An ultra simple hello-world function has been written in each AWS supported runt
 - `python3.8`
 - `python3.9`
 - `python3.10`
+- `python3.11`
 - `dotnetcore3.1`
 - `dotnet6`
 - `go1.x`

--- a/manifest.json
+++ b/manifest.json
@@ -52,6 +52,13 @@
       "architectures": ["x86_64", "arm64"]
     },
     {
+      "displayName": "python3.11",
+      "runtime": "python3.11",
+      "handler": "index.handler",
+      "path": "python311",
+      "architectures": ["x86_64", "arm64"]
+    },
+    {
       "displayName": "dotnet6",
       "runtime": "dotnet6",
       "handler": "LambdaPerf::LambdaPerf.Function::Handler",

--- a/s3-uploader/runtimes/python311/build.sh
+++ b/s3-uploader/runtimes/python311/build.sh
@@ -1,0 +1,6 @@
+DIR_NAME="./runtimes/$1"
+ARCH=$2
+
+rm ${DIR_NAME}/code_${ARCH}.zip 2> /dev/null
+
+zip -j ${DIR_NAME}/code_${ARCH}.zip ${DIR_NAME}/index.py

--- a/s3-uploader/runtimes/python311/index.py
+++ b/s3-uploader/runtimes/python311/index.py
@@ -1,0 +1,4 @@
+def handler(event, context):
+    return {
+        'statusCode': 200,
+    }


### PR DESCRIPTION
https://aws.amazon.com/blogs/compute/python-3-11-runtime-now-available-in-aws-lambda/