### PR TITLE
Add bun support

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "memorySizes": [128, 256, 512, 1024],
   "runtimes": [
     {
-      "displayName": "apple swift 5.8",
+      "displayName": "apple swift 5.8 (prov.al2)",
       "runtime": "provided.al2",
       "handler": "SimpleLambdaHandler",
       "path": "swift58",
@@ -187,14 +187,14 @@
       "architectures": ["x86_64", "arm64"]
     },
     {
-      "displayName": "c++ 11",
+      "displayName": "c++ 11 (prov.al2)",
       "runtime": "provided.al2",
       "handler": "handler",
       "path": "cpp11",
       "architectures": ["x86_64", "arm64"]
     },
     {
-      "displayName": "bun",
+      "displayName": "bun (prov.al2)",
       "runtime": "provided.al2",
       "handler": "index.hello",
       "path": "bun",

--- a/manifest.json
+++ b/manifest.json
@@ -192,6 +192,17 @@
       "handler": "handler",
       "path": "cpp11",
       "architectures": ["x86_64", "arm64"]
+    },
+    {
+      "displayName": "bun",
+      "runtime": "provided.al2",
+      "handler": "index.hello",
+      "path": "bun",
+      "architectures": ["x86_64"],
+      "layer": {
+        "x86_64": "arn:aws:lambda:_REGION_:226609089145:layer:bun-1_0_0-x64:1",
+        "arm64": "arn:aws:lambda:_REGION_:226609089145:layer:bun-1_0_0-aarch64:1"
+      }
     }
   ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -200,8 +200,7 @@
       "path": "bun",
       "architectures": ["x86_64"],
       "layer": {
-        "x86_64": "arn:aws:lambda:_REGION_:226609089145:layer:bun-1_0_0-x64:1",
-        "arm64": "arn:aws:lambda:_REGION_:226609089145:layer:bun-1_0_0-aarch64:1"
+        "x86_64": "arn:aws:lambda:_REGION_:226609089145:layer:bun-1_0_0-x64:1"
       }
     }
   ]

--- a/s3-uploader/runtimes/bun/build.sh
+++ b/s3-uploader/runtimes/bun/build.sh
@@ -1,0 +1,6 @@
+DIR_NAME="./runtimes/$1"
+ARCH=$2
+
+rm ${DIR_NAME}/code_${ARCH}.zip 2> /dev/null
+
+zip -j ${DIR_NAME}/code_${ARCH}.zip ${DIR_NAME}/index.js

--- a/s3-uploader/runtimes/bun/index.js
+++ b/s3-uploader/runtimes/bun/index.js
@@ -1,0 +1,7 @@
+// handler.ts
+var handler_default = {
+  async hello() {
+    return new Response();
+  },
+};
+export { handler_default as default };

--- a/serverless.yaml
+++ b/serverless.yaml
@@ -51,7 +51,7 @@ provider:
       Resource: "arn:aws:lambda:${aws:region}:${aws:accountId}:function:lambda-perf-*"
     - Effect: Allow
       Action: "lambda:GetLayerVersion"
-      Resource: "arn:aws:lambda:eu-west-1:*:layer:*:*"
+      Resource: "arn:aws:lambda:*:*:layer:*:*"
     - Effect: Allow
       Action: "lambda:ListVersionsByFunction"
       Resource: "arn:aws:lambda:${aws:region}:${aws:accountId}:function:lambda-perf-*"

--- a/serverless.yaml
+++ b/serverless.yaml
@@ -50,6 +50,9 @@ provider:
       Action: "lambda:GetFunctionConfiguration"
       Resource: "arn:aws:lambda:${aws:region}:${aws:accountId}:function:lambda-perf-*"
     - Effect: Allow
+      Action: "lambda:GetLayerVersion"
+      Resource: "arn:aws:lambda:eu-west-1:*:layer:*:*"
+    - Effect: Allow
       Action: "lambda:ListVersionsByFunction"
       Resource: "arn:aws:lambda:${aws:region}:${aws:accountId}:function:lambda-perf-*"
     - Effect: Allow


### PR DESCRIPTION
This PR:

- adds the `layer` field support on the manifest (single value, no need for an array for now)
- adds `lambda:GetLayerVersion` IAM permission since it's needed to deploy a function using a layer
- adds support for bun

fix for #602

