### PR TITLE
Optimize the C++ cold start by decreasing the size of the package

### DIFF
--- a/s3-uploader/runtimes/cpp11/lambda/CMakeLists.txt
+++ b/s3-uploader/runtimes/cpp11/lambda/CMakeLists.txt
@@ -8,4 +8,4 @@ target_compile_features(${PROJECT_NAME} PRIVATE "cxx_std_11")
 target_compile_options(${PROJECT_NAME} PRIVATE "-Wall" "-Wextra")
 
 # this line creates a target that packages your binary and zips it up
-aws_lambda_package_target(${PROJECT_NAME})
+aws_lambda_package_target(${PROJECT_NAME} NO_LIBC)


### PR DESCRIPTION
Technically we should be using the `lambda/provided:al2` container image to do this safely.
But since the Lambda function does not do anything except return "OK", There's a good change this might just work.

Fixes #711