### PR TITLE
rm lib as they're not needed any more

### DIFF
--- a/s3-uploader/runtimes/cpp11/Dockerfile
+++ b/s3-uploader/runtimes/cpp11/Dockerfile
@@ -18,6 +18,8 @@ RUN mkdir build
 WORKDIR "${APP_BASE_DIR}/lambda/build"
 RUN cmake3 .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=~/lambda-install
 RUN make && make aws-lambda-package-maxdaylambda
+# /lib folder is actually useless
+RUN zip -d maxdaylambda.zip 'lib/*'
 
 FROM scratch
 COPY --from=builder /tmp/app/lambda/build/maxdaylambda.zip /code.zip


### PR DESCRIPTION
rm lib/* from the package as all libs are already present on provided.al2 image (see #727)