### PR TITLE
Build libcurl as a static library for C++ Lambda runtime

### DIFF
--- a/s3-uploader/runtimes/cpp11/Dockerfile
+++ b/s3-uploader/runtimes/cpp11/Dockerfile
@@ -1,5 +1,4 @@
-ARG ARCH
-FROM public.ecr.aws/lambda/provided:al2-$ARCH AS builder
+FROM public.ecr.aws/lambda/provided:al2 AS builder
 ENV APP_BASE_DIR=/tmp/app
 WORKDIR $APP_BASE_DIR
 RUN yum install cmake3 git zip autoconf automake -y
@@ -14,7 +13,7 @@ RUN tar -xvf curl-7.88.1.tar.gz
 WORKDIR "${APP_BASE_DIR}/curl-7.88.1"
 RUN autoreconf -fi
 RUN ./configure --disable-shared --disable-pthreads --disable-threaded-resolver \
---with-pic --without-ssl --without-zlib --prefix=${APP_BASE_DIR}/lambda-install
+--with-pic --without-ssl --without-zlib
 RUN make -j && make install
 # Build the C++ Lambda runtime
 WORKDIR "${APP_BASE_DIR}"

--- a/s3-uploader/runtimes/cpp11/Dockerfile
+++ b/s3-uploader/runtimes/cpp11/Dockerfile
@@ -1,25 +1,35 @@
-FROM public.ecr.aws/lambda/provided:al2 as builder
+ARG ARCH
+FROM public.ecr.aws/lambda/provided:al2-$ARCH AS builder
 ENV APP_BASE_DIR=/tmp/app
 WORKDIR $APP_BASE_DIR
-RUN yum install cmake3 make g++ git zip libcurl-devel zlib-devel openssl-devel -y
+RUN yum install cmake3 git zip autoconf automake -y
 RUN yum groupinstall "Development Tools" -y
 
 COPY . $APP_BASE_DIR
 WORKDIR $APP_BASE_DIR
 SHELL ["/bin/bash", "-c"]
+# Build static libcurl from source
+RUN curl -O https://curl.se/download/curl-7.88.1.tar.gz
+RUN tar -xvf curl-7.88.1.tar.gz
+WORKDIR "${APP_BASE_DIR}/curl-7.88.1"
+RUN autoreconf -fi
+RUN ./configure --disable-shared --disable-pthreads --disable-threaded-resolver \
+--with-pic --without-ssl --without-zlib --prefix=${APP_BASE_DIR}/lambda-install
+RUN make -j && make install
+# Build the C++ Lambda runtime
+WORKDIR "${APP_BASE_DIR}"
 RUN git clone https://github.com/awslabs/aws-lambda-cpp.git
 WORKDIR "${APP_BASE_DIR}/aws-lambda-cpp/"
 RUN mkdir build
 WORKDIR "${APP_BASE_DIR}/aws-lambda-cpp/build"
 RUN cmake3 .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=~/lambda-install
 RUN make && make install
+# Build the Lambda function
 WORKDIR "${APP_BASE_DIR}/lambda/"
 RUN mkdir build
 WORKDIR "${APP_BASE_DIR}/lambda/build"
 RUN cmake3 .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=~/lambda-install
 RUN make && make aws-lambda-package-maxdaylambda
-# /lib folder is actually useless
-RUN zip -d maxdaylambda.zip 'lib/*'
 
 FROM scratch
 COPY --from=builder /tmp/app/lambda/build/maxdaylambda.zip /code.zip

--- a/s3-uploader/runtimes/cpp11/lambda/CMakeLists.txt
+++ b/s3-uploader/runtimes/cpp11/lambda/CMakeLists.txt
@@ -5,7 +5,7 @@ find_package(aws-lambda-runtime)
 add_executable(${PROJECT_NAME} "main.cpp")
 target_link_libraries(${PROJECT_NAME} PRIVATE AWS::aws-lambda-runtime)
 target_compile_features(${PROJECT_NAME} PRIVATE "cxx_std_11")
-target_compile_options(${PROJECT_NAME} PRIVATE "-Wall" "-Wextra")
+target_compile_options(${PROJECT_NAME} PRIVATE "-Wall" "-Wextra" "-fno-rtti" "-fno-exceptions")
 
 # this line creates a target that packages your binary and zips it up
 aws_lambda_package_target(${PROJECT_NAME} NO_LIBC)


### PR DESCRIPTION
By building and linking libcurl statically, we minimize the number of libraries that need to be dynamically linked, thereby reducing the cold start time.