### PR TITLE
Add `nodejs20.x`

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ An ultra simple hello-world function has been written in each AWS supported runt
 - `nodejs14.x`
 - `nodejs16.x`
 - `nodejs18.x`
+- `nodejs20.x`
 - `python3.7`
 - `python3.8`
 - `python3.9`

--- a/manifest.json
+++ b/manifest.json
@@ -30,6 +30,13 @@
       "architectures": ["x86_64", "arm64"]
     },
     {
+      "displayName": "nodejs20.x",
+      "runtime": "nodejs20.x",
+      "handler": "index.handler",
+      "path": "nodejs20x",
+      "architectures": ["x86_64", "arm64"]
+    },
+    {
       "displayName": "python3.7",
       "runtime": "python3.7",
       "handler": "index.handler",

--- a/s3-uploader/runtimes/nodejs20x/build.sh
+++ b/s3-uploader/runtimes/nodejs20x/build.sh
@@ -1,0 +1,6 @@
+DIR_NAME="./runtimes/$1"
+ARCH=$2
+
+rm ${DIR_NAME}/code_${ARCH}.zip 2> /dev/null
+
+zip -j ${DIR_NAME}/code_${ARCH}.zip ${DIR_NAME}/index.js

--- a/s3-uploader/runtimes/nodejs20x/index.js
+++ b/s3-uploader/runtimes/nodejs20x/index.js
@@ -1,0 +1,5 @@
+exports.handler = () => {
+    return {
+        statusCode: 200
+    };
+};


### PR DESCRIPTION
AWS added support for Node.js 20 in the past few days.
- [aws-sdk release](https://github.com/aws/aws-sdk-js-v3/releases/tag/v3.446.0)
- [PR for aws-cdk](https://github.com/aws/aws-cdk/pull/27897)

Related [comment from AWS](https://github.com/aws/aws-lambda-base-images/issues/91#issuecomment-1737694321).