### PR TITLE
[C++] Pass the request by reference

### DIFF
--- a/s3-uploader/runtimes/cpp11_on_provided_al2/lambda/main.cpp
+++ b/s3-uploader/runtimes/cpp11_on_provided_al2/lambda/main.cpp
@@ -2,7 +2,7 @@
 
 using namespace aws::lambda_runtime;
 
-static invocation_response handler(invocation_request)
+static invocation_response handler(invocation_request const&)
 {
     return invocation_response::success("Ok", "text/plain");
 }

--- a/s3-uploader/runtimes/cpp11_on_provided_al2023/lambda/main.cpp
+++ b/s3-uploader/runtimes/cpp11_on_provided_al2023/lambda/main.cpp
@@ -2,7 +2,7 @@
 
 using namespace aws::lambda_runtime;
 
-static invocation_response handler(invocation_request)
+static invocation_response handler(invocation_request const&)
 {
     return invocation_response::success("Ok", "text/plain");
 }


### PR DESCRIPTION
This eliminates a bunch of unnecessary copying of fields like headers, payload, etc.