### PR TITLE
Fix source/targetCompatibility of java >8 runtimes

### DIFF
--- a/s3-uploader/runtimes/java11/build.gradle
+++ b/s3-uploader/runtimes/java11/build.gradle
@@ -4,8 +4,8 @@ repositories {
     mavenCentral()
 }
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 11
+targetCompatibility = 11
 
 task buildZip(type: Zip) {
     archiveBaseName = 'code'

--- a/s3-uploader/runtimes/java11_snapstart/build.gradle
+++ b/s3-uploader/runtimes/java11_snapstart/build.gradle
@@ -4,8 +4,8 @@ repositories {
     mavenCentral()
 }
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 11
+targetCompatibility = 11
 
 task buildZip(type: Zip) {
     archiveBaseName = 'code'

--- a/s3-uploader/runtimes/java17/build.gradle
+++ b/s3-uploader/runtimes/java17/build.gradle
@@ -4,8 +4,8 @@ repositories {
     mavenCentral()
 }
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 17
+targetCompatibility = 17
 
 task buildZip(type: Zip) {
     archiveBaseName = 'code'

--- a/s3-uploader/runtimes/java17_snapstart/build.gradle
+++ b/s3-uploader/runtimes/java17_snapstart/build.gradle
@@ -4,8 +4,8 @@ repositories {
     mavenCentral()
 }
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 17
+targetCompatibility = 17
 
 task buildZip(type: Zip) {
     archiveBaseName = 'code'

--- a/s3-uploader/runtimes/java21/build.gradle
+++ b/s3-uploader/runtimes/java21/build.gradle
@@ -4,8 +4,8 @@ repositories {
     mavenCentral()
 }
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 21
+targetCompatibility = 21
 
 task buildZip(type: Zip) {
     archiveBaseName = 'code'

--- a/s3-uploader/runtimes/java21_snapstart/build.gradle
+++ b/s3-uploader/runtimes/java21_snapstart/build.gradle
@@ -4,8 +4,8 @@ repositories {
     mavenCentral()
 }
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 21
+targetCompatibility = 21
 
 task buildZip(type: Zip) {
     archiveBaseName = 'code'


### PR DESCRIPTION
All Java runtimes > 8 were configured with source- and targetCompatibility 1.8 (java 8).

This means the bytecode produced by the project is java 8 compatible and cant make use of optimizations done in newer java versions. This might have a slight influence on the startup time