### PR TITLE
Use ReadyToRun on dotnet6 lambda

### DIFF
--- a/s3-uploader/runtimes/dotnet6/src/LambdaPerf.csproj
+++ b/s3-uploader/runtimes/dotnet6/src/LambdaPerf.csproj
@@ -4,6 +4,7 @@
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />


### PR DESCRIPTION
This is following the typical practice when creating a dotnet lambda from the AWS template:
https://github.com/aws/aws-lambda-dotnet/blob/2eb29ad5de3910677040b14c53f1e3f79f611453/Blueprints/BlueprintDefinitions/vs2022/EmptyFunction/template/src/BlueprintBaseName.1/BlueprintBaseName.1.csproj#L11