### PR TITLE
Strip debuginfo for Rust runtime to reduce binary size

### DIFF
--- a/s3-uploader/runtimes/rust_on_provided_al2/Cargo.toml
+++ b/s3-uploader/runtimes/rust_on_provided_al2/Cargo.toml
@@ -13,3 +13,4 @@ opt-level = 'z'
 lto = true
 codegen-units = 1
 panic = 'abort'
+strip = 'debuginfo'

--- a/s3-uploader/runtimes/rust_on_provided_al2023/Cargo.toml
+++ b/s3-uploader/runtimes/rust_on_provided_al2023/Cargo.toml
@@ -13,3 +13,4 @@ opt-level = 'z'
 lto = true
 codegen-units = 1
 panic = 'abort'
+strip = 'debuginfo'


### PR DESCRIPTION
Strip debuginfo for Rust runtime to reduce binary size. For the Rust AL2 runtime it reduced the binary size by about 18.18% (1.1 MB -> 929 KB). See relevant article: https://kobzol.github.io/rust/cargo/2024/01/23/making-rust-binaries-smaller-by-default.html