### PR TITLE
Strip symbols and debuginfo from Rust runtime to reduce binary size

### DIFF
--- a/s3-uploader/runtimes/rust_on_provided_al2/Cargo.toml
+++ b/s3-uploader/runtimes/rust_on_provided_al2/Cargo.toml
@@ -13,4 +13,4 @@ opt-level = 'z'
 lto = true
 codegen-units = 1
 panic = 'abort'
-strip = 'debuginfo'
+strip = true

--- a/s3-uploader/runtimes/rust_on_provided_al2023/Cargo.toml
+++ b/s3-uploader/runtimes/rust_on_provided_al2023/Cargo.toml
@@ -13,4 +13,4 @@ opt-level = 'z'
 lto = true
 codegen-units = 1
 panic = 'abort'
-strip = 'debuginfo'
+strip = true


### PR DESCRIPTION
I released the change to strip the 'debuginfo', but then realized we can also strip symbols as well to reduce the binary size even further. On my machine I saw the binary size reduce from 927kb -> 637kb by stripping symbols in addition to debuginfo. An additional 31.2% drop in binary size beyond the drop from stripping only the debuginfo.

Reference: https://doc.rust-lang.org/cargo/reference/profiles.html#strip