### PR TITLE
Java 21 SnapStart Priming

### DIFF
--- a/s3-uploader/runtimes/java21_snapstart/build.gradle
+++ b/s3-uploader/runtimes/java21_snapstart/build.gradle
@@ -4,6 +4,10 @@ repositories {
     mavenCentral()
 }
 
+dependencies {
+    implementation 'org.crac:crac:1.4.0'
+}
+
 sourceCompatibility = 21
 targetCompatibility = 21
 

--- a/s3-uploader/runtimes/java21_snapstart/build.gradle
+++ b/s3-uploader/runtimes/java21_snapstart/build.gradle
@@ -15,6 +15,9 @@ task buildZip(type: Zip) {
     archiveBaseName = 'code'
     from compileJava
     from processResources
+    into('lib') {
+        from configurations.runtimeClasspath
+    }
 }
 
 build.dependsOn buildZip

--- a/s3-uploader/runtimes/java21_snapstart/src/main/java/io/github/maxday/Handler.java
+++ b/s3-uploader/runtimes/java21_snapstart/src/main/java/io/github/maxday/Handler.java
@@ -1,10 +1,19 @@
 package io.github.maxday;
 
+import org.crac.Context;
+import org.crac.Core;
+import org.crac.Resource;
+
+import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 
-public class Handler {
+public class Handler implements Resource {
+
+    public Handler() {
+        Core.getGlobalContext().register(this);
+    }
 
     public void handleRequest(InputStream inputStream, OutputStream outputStream) throws IOException {
         try {
@@ -14,5 +23,19 @@ public class Handler {
         } finally {
             outputStream.close();
         }
+    }
+
+    // Making best use of the snapshotting, by priming the function
+    // https://aws.amazon.com/blogs/compute/reducing-java-cold-starts-on-aws-lambda-functions-with-snapstart/
+    @Override
+    public void beforeCheckpoint(Context<? extends Resource> context) throws Exception {
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            outputStream.write("ok".getBytes());
+        }
+    }
+
+    @Override
+    public void afterRestore(Context<? extends Resource> context) throws Exception {
+        // intentionally empty
     }
 }


### PR DESCRIPTION
This is a tough benchmark for Lambda SnapStart. It caches snapshots so the first restore of a Lambda version is always slower than future ones. 

One technique to improve the first restore latency is to have the JVM load and initialize classes before the snapshot is taken. This can be done using the CRaC APIs. In this PR I've made a before hook that does the same thing as the handler. It will mean that those classes are already compiled and stored in the snapshot when the handler is invoked.