### PR TITLE
Update Golang version to 1.22.

### DIFF
--- a/s3-uploader/runtimes/go_on_provided_al2/go.mod
+++ b/s3-uploader/runtimes/go_on_provided_al2/go.mod
@@ -1,5 +1,5 @@
 module lambdaperf
 
-go 1.19
+go 1.22
 
-require github.com/aws/aws-lambda-go v1.40.0
+require github.com/aws/aws-lambda-go v1.41.0

--- a/s3-uploader/runtimes/go_on_provided_al2023/go.mod
+++ b/s3-uploader/runtimes/go_on_provided_al2023/go.mod
@@ -1,5 +1,5 @@
 module lambdaperf
 
-go 1.19
+go 1.22
 
-require github.com/aws/aws-lambda-go v1.40.0
+require github.com/aws/aws-lambda-go v1.41.0


### PR DESCRIPTION
The previously used 1.19 was the first release after generics addition so there was certain performance impact. The newer versions are gaining back the speed, so would be interesting to see how 1.22 performs.

Update aws-lambda-go dependency to latest while here.