### PR TITLE
fix go to prevent missing toolchain error

### DIFF
--- a/s3-uploader/runtimes/go_on_provided_al2/go.mod
+++ b/s3-uploader/runtimes/go_on_provided_al2/go.mod
@@ -1,5 +1,5 @@
 module lambdaperf
 
-go 1.22
+go 1.22.0
 
 require github.com/aws/aws-lambda-go v1.46.0

--- a/s3-uploader/runtimes/go_on_provided_al2023/go.mod
+++ b/s3-uploader/runtimes/go_on_provided_al2023/go.mod
@@ -1,5 +1,5 @@
 module lambdaperf
 
-go 1.22
+go 1.22.0
 
 require github.com/aws/aws-lambda-go v1.46.0


### PR DESCRIPTION
fix for
go: download go1.22 for linux/amd64: toolchain not available