### PR TITLE
Add Node.js 22

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ An ultra simple hello-world function has been written in each AWS supported runt
 - `nodejs16.x`
 - `nodejs18.x`
 - `nodejs20.x`
+- `nodejs22.x`
 - `python3.8`
 - `python3.9`
 - `python3.10`

--- a/manifest.json
+++ b/manifest.json
@@ -42,6 +42,16 @@
       }
     },
     {
+      "displayName": "nodejs22.x",
+      "runtime": "nodejs22.x",
+      "handler": "index.handler",
+      "path": "nodejs22x",
+      "architectures": ["x86_64", "arm64"],
+      "image": {
+        "baseImage": "public.ecr.aws/lambda/nodejs:22"
+      }
+    },
+    {
       "displayName": "python3.8",
       "runtime": "python3.8",
       "handler": "index.handler",

--- a/s3-uploader/runtimes/nodejs22x/build.sh
+++ b/s3-uploader/runtimes/nodejs22x/build.sh
@@ -1,0 +1,6 @@
+DIR_NAME="./runtimes/$1"
+ARCH=$2
+
+rm ${DIR_NAME}/code_${ARCH}.zip 2> /dev/null
+
+zip -j ${DIR_NAME}/code_${ARCH}.zip ${DIR_NAME}/index.js

--- a/s3-uploader/runtimes/nodejs22x/index.js
+++ b/s3-uploader/runtimes/nodejs22x/index.js
@@ -1,0 +1,5 @@
+exports.handler = () => {
+    return {
+        statusCode: 200
+    };
+};


### PR DESCRIPTION
Node.js 22 runtime is available, see the [AWS announcement post](https://aws.amazon.com/blogs/compute/node-js-22-runtime-now-available-in-aws-lambda/).

I would like to see how it performs (now and better over time).

Fixes #1642 