### PR TITLE
fix: no-fallback was failing in graalvm17

### DIFF
--- a/s3-uploader/runtimes/graalvm_java17_on_provided_al2/pom.xml
+++ b/s3-uploader/runtimes/graalvm_java17_on_provided_al2/pom.xml
@@ -112,7 +112,6 @@
                                 <!-- BouncyCastleAlpn issue tracked in https://github.com/netty/netty/issues/11369 -->
                                 <buildArgs>
                                     --verbose
-                                    --no-fallback
                                     --initialize-at-build-time=org.slf4j
                                     --initialize-at-run-time=io.netty.handler.ssl.BouncyCastleAlpnSslUtils
                                     --enable-url-protocols=http


### PR DESCRIPTION
`no-fallback` is not recognized as an option anymore and the build was failing, this PR removes it