### PR TITLE
fix: rust al2

### DIFF
--- a/s3-uploader/runtimes/rust_on_provided_al2/Dockerfile
+++ b/s3-uploader/runtimes/rust_on_provided_al2/Dockerfile
@@ -1,7 +1,6 @@
 FROM public.ecr.aws/lambda/provided:al2 as builder
 ARG ARCH
 WORKDIR /usr/src/app
-RUN yum -y update
 RUN yum -y install openssl openssl-devel
 RUN yum -y install gcc
 RUN yum -y install zip

--- a/s3-uploader/runtimes/rust_on_provided_al2/Dockerfile
+++ b/s3-uploader/runtimes/rust_on_provided_al2/Dockerfile
@@ -8,14 +8,10 @@ RUN yum -y install python3-pip
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 RUN source $HOME/.cargo/env
 COPY Cargo.toml .
-RUN mkdir ./src && echo 'fn main() { println!("Dummy!"); }' > ./src/lib.rs
-RUN /root/.cargo/bin/cargo build --release
-RUN rm -rf ./src
 COPY src ./src
-RUN touch -a -m ./src/lib.rs
-RUN pip3 install cargo-lambda
-RUN /root/.cargo/bin/cargo lambda build --release --${ARCH}
-RUN zip -j /tmp/code.zip target/lambda/lambda-perf/bootstrap
+RUN /root/.cargo/bin/cargo build --release
+RUN mv target/release/lambda-perf target/release/bootstrap
+RUN zip -j /tmp/code.zip target/release/bootstrap
 
 FROM scratch
 COPY --from=builder /tmp/code.zip /


### PR DESCRIPTION
simplify the Dockerfile to use cargo release directly.
previously linked GLIBC version was incorrect and incompatible with al2