### PR TITLE
fix: arch for graalvm

### DIFF
--- a/s3-uploader/runtimes/graalvm_java17_on_provided_al2/pom.xml
+++ b/s3-uploader/runtimes/graalvm_java17_on_provided_al2/pom.xml
@@ -115,6 +115,7 @@
                                 <buildArg>--initialize-at-build-time=org.slf4j</buildArg>
                                 <buildArg>--initialize-at-run-time=io.netty.handler.ssl.BouncyCastleAlpnSslUtils</buildArg>
                                 <buildArg>--enable-url-protocols=http</buildArg>
+                                <buildArg>-H:+AddAllCharsets -march=compatibility</buildArg>
                                 <buildArg>-H:ReflectionConfigurationFiles=${project.basedir}/src/main/resources/reflect.json</buildArg>
                             </buildArgs>
                         </configuration>

--- a/s3-uploader/runtimes/graalvm_java21_on_provided_al2023/pom.xml
+++ b/s3-uploader/runtimes/graalvm_java21_on_provided_al2023/pom.xml
@@ -111,14 +111,13 @@
                             <mainClass>com.formkiq.lambda.runtime.graalvm.LambdaRuntime</mainClass>
                             <buildArgs combine.children="append">
                                 <!-- BouncyCastleAlpn issue tracked in https://github.com/netty/netty/issues/11369 -->
-                                <buildArgs>
-                                    --verbose
-                                    --no-fallback
-                                    --initialize-at-build-time=org.slf4j
-                                    --initialize-at-run-time=io.netty.handler.ssl.BouncyCastleAlpnSslUtils
-                                    --enable-url-protocols=http
-                                    -H:ReflectionConfigurationFiles=${project.basedir}/src/main/resources/reflect.json
-                                </buildArgs>
+                                <buildArg>--verbose</buildArg>
+                                <buildArg>--no-fallback</buildArg>
+                                <buildArg>--initialize-at-build-time=org.slf4j</buildArg>
+                                <buildArg>--initialize-at-run-time=io.netty.handler.ssl.BouncyCastleAlpnSslUtils</buildArg>
+                                <buildArg>--enable-url-protocols=http</buildArg>
+                                <buildArg>-H:+AddAllCharsets -march=compatibility</buildArg>
+                                <buildArg>-H:ReflectionConfigurationFiles=${project.basedir}/src/main/resources/reflect.json</buildArg>
                             </buildArgs>
                         </configuration>
                     </plugin>


### PR DESCRIPTION
fix: `The current machine does not support all of the following CPU features that are required by the image: [CX8, CMOV, FXSR, MMX, SSE, SSE2, SSE3, SSSE3, SSE4_1, SSE4_2, POPCNT, LZCNT, AVX, AVX2, BMI1, BMI2, FMA].
Please rebuild the executable with an appropriate setting of the -march option.`