### PR TITLE
Add dotnet9 aot to benchmarks

### DIFF
--- a/s3-uploader/runtimes/dotnet9_aot_on_provided_al2023/Dockerfile
+++ b/s3-uploader/runtimes/dotnet9_aot_on_provided_al2023/Dockerfile
@@ -1,0 +1,15 @@
+ARG IMAGE_TAG
+FROM $IMAGE_TAG/amazonlinux:2023 AS builder
+ARG ARCH
+WORKDIR /tmp
+COPY src .
+RUN yum update -y && yum install -y clang zlib-devel krb5-devel openssl-devel zip gzip tar wget
+RUN wget https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh && chmod +x ./dotnet-install.sh && ./dotnet-install.sh --version latest
+ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1
+ENV SSL_CERT_FILE=/tmp/noop
+RUN /root/.dotnet/dotnet publish --configuration Release --arch $ARCH --output /tmp/publish
+RUN zip -j /tmp/code.zip /tmp/publish/bootstrap
+
+FROM scratch
+COPY --from=builder /tmp/code.zip /
+ENTRYPOINT ["/code.zip"]

--- a/s3-uploader/runtimes/dotnet9_aot_on_provided_al2023/build.sh
+++ b/s3-uploader/runtimes/dotnet9_aot_on_provided_al2023/build.sh
@@ -1,0 +1,20 @@
+DIR_NAME="./runtimes/$1"
+
+if [ $2 = "x86_64" ]; then
+    ARCH="x64"
+    IMAGE_TAG="amd64"
+    PLATFORM="linux/amd64"
+elif [ $2 = "arm64" ]; then
+    ARCH="arm64"
+    IMAGE_TAG="arm64v8"
+    PLATFORM="linux/arm64"
+else
+    echo "The process architecture $2 is set incorrectly. The value can only be either x86_64 or arm64."
+    exit 1
+fi
+
+rm ${DIR_NAME}/code_${2}.zip 2> /dev/null
+
+docker build --platform ${PLATFORM} ${DIR_NAME} --build-arg ARCH=${ARCH} --build-arg IMAGE_TAG=${IMAGE_TAG} -t maxday/dotnet9_on_provided_al2023_${2}
+dockerId=$(docker create maxday/dotnet9_on_provided_al2023_${2})
+docker cp $dockerId:/code.zip ${DIR_NAME}/code_${2}.zip

--- a/s3-uploader/runtimes/dotnet9_aot_on_provided_al2023/src/Function.cs
+++ b/s3-uploader/runtimes/dotnet9_aot_on_provided_al2023/src/Function.cs
@@ -1,0 +1,28 @@
+using Amazon.Lambda.RuntimeSupport;
+using Amazon.Lambda.Serialization.SystemTextJson;
+using System.Text.Json.Serialization;
+
+namespace LambdaPerf;
+
+public class Function
+{
+    private static async Task Main()
+    {
+        await LambdaBootstrapBuilder.Create(FunctionHandler, new SourceGeneratorLambdaJsonSerializer<LambdaFunctionJsonSerializerContext>())
+            .Build()
+            .RunAsync();
+    }
+
+    public static StatusResponse FunctionHandler()
+    {
+        return new StatusResponse(StatusCode: 200);
+    }
+}
+
+public record StatusResponse(int StatusCode);
+
+[JsonSerializable(typeof(StatusResponse))]
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+public partial class LambdaFunctionJsonSerializerContext : JsonSerializerContext
+{
+}

--- a/s3-uploader/runtimes/dotnet9_aot_on_provided_al2023/src/LambdaPerf.csproj
+++ b/s3-uploader/runtimes/dotnet9_aot_on_provided_al2023/src/LambdaPerf.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AWSProjectType>Lambda</AWSProjectType>
+    <OutputType>Exe</OutputType>
+    <AssemblyName>bootstrap</AssemblyName>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <PublishAot>true</PublishAot>
+    <StripSymbols>true</StripSymbols>
+    <TieredCompilation>false</TieredCompilation>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <OptimizationPreference>Speed</OptimizationPreference>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.12.2" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="2.5.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.4" />
+  </ItemGroup>
+
+</Project>

--- a/s3-uploader/runtimes/dotnet9_aot_on_provided_al2023/src/aws-lambda-tools-defaults.json
+++ b/s3-uploader/runtimes/dotnet9_aot_on_provided_al2023/src/aws-lambda-tools-defaults.json
@@ -1,0 +1,9 @@
+{
+  "configuration": "Release",
+  "environment-variables" : "SSL_CERT_FILE=/tmp/noop",
+  "framework": "net9.0",
+  "function-runtime": "provided.al2023",
+  "function-memory-size": 256,
+  "function-timeout": 30,
+  "function-handler": "bootstrap"
+}


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*

Adds dotnet9 aot to the benchmarks. Created from https://github.com/maxday/lambda-perf/pull/1626

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
