### PR TITLE
fix: remove NO_GLIBC flag for al2023

### DIFF
--- a/s3-uploader/runtimes/cpp11_on_provided_al2023/lambda/CMakeLists.txt
+++ b/s3-uploader/runtimes/cpp11_on_provided_al2023/lambda/CMakeLists.txt
@@ -8,4 +8,4 @@ target_compile_features(${PROJECT_NAME} PRIVATE "cxx_std_11")
 target_compile_options(${PROJECT_NAME} PRIVATE "-Wall" "-Wextra" "-fno-rtti" "-fno-exceptions")
 
 # this line creates a target that packages your binary and zips it up
-aws_lambda_package_target(${PROJECT_NAME} NO_LIBC)
+aws_lambda_package_target(${PROJECT_NAME})


### PR DESCRIPTION
## Description
emove NO_GLIBC flag which prevent the runtime from compiling on al2023

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.