### PR TITLE
Add support for python3.14 runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ An ultra simple hello-world function has been written in each AWS supported runt
 - `python3.11`
 - `python3.12`
 - `python3.13`
+- `python3.14`
 - `dotnet6`
 - `dotnet8`
 - `java11`

--- a/manifest.json
+++ b/manifest.json
@@ -122,6 +122,16 @@
       }
     },
     {
+      "displayName": "python3.14",
+      "runtime": "python3.14",
+      "handler": "index.handler",
+      "path": "python314",
+      "architectures": ["x86_64", "arm64"],
+      "image": {
+        "baseImage": "public.ecr.aws/lambda/python:3.14"
+      }
+    },
+    {
       "displayName": "dotnet6",
       "runtime": "dotnet6",
       "handler": "LambdaPerf::LambdaPerf.Function::Handler",

--- a/s3-uploader/runtimes/python314/build.sh
+++ b/s3-uploader/runtimes/python314/build.sh
@@ -1,0 +1,6 @@
+DIR_NAME="./runtimes/$1"
+ARCH=$2
+
+rm ${DIR_NAME}/code_${ARCH}.zip 2> /dev/null
+
+zip -j ${DIR_NAME}/code_${ARCH}.zip ${DIR_NAME}/index.py

--- a/s3-uploader/runtimes/python314/index.py
+++ b/s3-uploader/runtimes/python314/index.py
@@ -1,0 +1,4 @@
+def handler(event, context):
+    return {
+        "statusCode": 200,
+    }


### PR DESCRIPTION
# Pull Request Checklist

## For New Runtime Additions
- [x] Added the new runtime to the manifest.json file
- [x] Updated `README.md` to reflect the new runtime
- [x] Gave execution permission to `build.sh`
- [ ] If needed, updated `.github/dependabot.yml`
- [ ] If needed, updated `.gitignore`

## Description
Add support for python3.14 runtime https://aws.amazon.com/fr/about-aws/whats-new/2025/11/aws-lambda-python-314/

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.