### PR TITLE
feat(runtimes): add Java 25 runtime

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -106,6 +106,10 @@ updates:
     schedule:
       interval: "daily"
   - package-ecosystem: "gradle"
+    directory: "s3-uploader/runtimes/java25"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "gradle"
     directory: "s3-uploader/runtimes/java21_snapstart"
     schedule:
       interval: "daily"

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ docs/public
 docs/app.js
 docs/package.json
 docs/package-lock.json
+.idea
 
 target
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ An ultra simple hello-world function has been written in each AWS supported runt
 - `java11`
 - `java17`
 - `java21`
+- `java25`
 - `ruby3.2`
 - `ruby3.3`
 - `ruby3.4`

--- a/manifest.json
+++ b/manifest.json
@@ -292,6 +292,16 @@
       }
     },
     {
+      "displayName": "java25",
+      "runtime": "java25",
+      "handler": "io.github.maxday.Handler::handleRequest",
+      "path": "java25",
+      "architectures": ["x86_64", "arm64"],
+      "image": {
+        "baseImage": "public.ecr.aws/lambda/java:25"
+      }
+    },
+    {
       "displayName": "quarkus (prov.al2)",
       "runtime": "provided.al2",
       "handler": "bootstrap",

--- a/s3-uploader/runtimes/java25/Dockerfile
+++ b/s3-uploader/runtimes/java25/Dockerfile
@@ -1,0 +1,16 @@
+FROM public.ecr.aws/lambda/java:25 AS builder
+WORKDIR /tmpBuild
+RUN dnf -y update
+RUN dnf -y install zip
+RUN dnf -y install findutils
+RUN  curl -k -L -v -X GET https://services.gradle.org/distributions/gradle-8.3-bin.zip > gradle-8.3-bin.zip
+RUN unzip -d /opt/gradle gradle-8.3-bin.zip
+
+COPY src ./src
+COPY build.gradle .
+
+RUN JAVA_HOME=/var/lang /opt/gradle/gradle-8.3/bin/gradle :buildZip
+
+FROM scratch
+COPY --from=builder /tmpBuild/build/distributions/code.zip /
+ENTRYPOINT ["/code.zip"]

--- a/s3-uploader/runtimes/java25/build.gradle
+++ b/s3-uploader/runtimes/java25/build.gradle
@@ -1,0 +1,16 @@
+apply plugin: 'java'
+
+repositories {
+    mavenCentral()
+}
+
+sourceCompatibility = 25
+targetCompatibility = 25
+
+task buildZip(type: Zip) {
+    archiveBaseName = 'code'
+    from compileJava
+    from processResources
+}
+
+build.dependsOn buildZip

--- a/s3-uploader/runtimes/java25/build.sh
+++ b/s3-uploader/runtimes/java25/build.sh
@@ -1,0 +1,8 @@
+DIR_NAME="./runtimes/$1"
+ARCH=$2
+
+rm ${DIR_NAME}/code_${ARCH}.zip 2> /dev/null
+
+docker build ${DIR_NAME} -t maxday/java25
+dockerId=$(docker create maxday/java25)
+docker cp $dockerId:/code.zip ${DIR_NAME}/code_${ARCH}.zip

--- a/s3-uploader/runtimes/java25/src/main/java/io/github/maxday/Handler.java
+++ b/s3-uploader/runtimes/java25/src/main/java/io/github/maxday/Handler.java
@@ -1,0 +1,18 @@
+package io.github.maxday;
+
+import java.io.InputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+public class Handler {
+
+    public void handleRequest(InputStream inputStream, OutputStream outputStream) throws IOException {
+        try {
+            outputStream.write("ok".getBytes());
+        } catch (IOException e) {
+            e.printStackTrace();
+        } finally {
+            outputStream.close();
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request Checklist

## For New Runtime Additions
- [x] Added the new runtime to the manifest.json file
- [x] Updated `README.md` to reflect the new runtime
- [x] Gave execution permission to `build.sh`
- [x] If needed, updated `.github/dependabot.yml`
- [x] If needed, updated `.gitignore`

## Description
AWS recently added Java25 runtime support. https://aws.amazon.com/blogs/compute/aws-lambda-now-supports-java-25/
I'm not sure yet if it requires anything new for the image based builds, but that can be added afterwards.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.