### PR TITLE
bumped maven version

### DIFF
--- a/s3-uploader/runtimes/graalvm_java17_on_provided_al2/Dockerfile
+++ b/s3-uploader/runtimes/graalvm_java17_on_provided_al2/Dockerfile
@@ -1,9 +1,10 @@
 FROM quay.io/quarkus/ubi-quarkus-mandrel-builder-image:23.0.1.2-Final-java17 AS builder
-RUN curl https://dlcdn.apache.org/maven/maven-3/3.9.12/binaries/apache-maven-3.9.12-bin.tar.gz --output apache-maven-3.9.12-bin.tar.gz
-RUN tar xzf apache-maven-3.9.12-bin.tar.gz
+
+RUN curl https://dlcdn.apache.org/maven/maven-3/3.9.16/binaries/apache-maven-3.9.16-bin.tar.gz --output apache-maven-3.9.16-bin.tar.gz
+RUN tar xzf apache-maven-3.9.16-bin.tar.gz
 COPY src ./src
 COPY pom.xml .
-RUN ./apache-maven-3.9.12/bin/mvn package -Pnative
+RUN ./apache-maven-3.9.16/bin/mvn package -Pnative
 
 # strip the binary
 FROM ubuntu AS stripper

--- a/s3-uploader/runtimes/graalvm_java21_on_provided_al2023/Dockerfile
+++ b/s3-uploader/runtimes/graalvm_java21_on_provided_al2023/Dockerfile
@@ -1,9 +1,9 @@
 FROM quay.io/quarkus/ubi-quarkus-mandrel-builder-image:23.1.2.0-Final-java21 AS builder
-RUN curl https://dlcdn.apache.org/maven/maven-3/3.9.12/binaries/apache-maven-3.9.12-bin.tar.gz --output apache-maven-3.9.12-bin.tar.gz
-RUN tar xzf apache-maven-3.9.12-bin.tar.gz
+RUN curl https://dlcdn.apache.org/maven/maven-3/3.9.16/binaries/apache-maven-3.9.16-bin.tar.gz --output apache-maven-3.9.16-bin.tar.gz
+RUN tar xzf apache-maven-3.9.16-bin.tar.gz
 COPY src ./src
 COPY pom.xml .
-RUN ./apache-maven-3.9.12/bin/mvn package -Pnative
+RUN ./apache-maven-3.9.16/bin/mvn package -Pnative
 
 # strip the binary
 FROM ubuntu AS stripper

--- a/s3-uploader/runtimes/graalvm_java23_on_provided_al2023/Dockerfile
+++ b/s3-uploader/runtimes/graalvm_java23_on_provided_al2023/Dockerfile
@@ -1,9 +1,9 @@
 FROM quay.io/quarkus/ubi-quarkus-mandrel-builder-image:24.1.1.0-Final-java23 AS builder
-RUN curl https://dlcdn.apache.org/maven/maven-3/3.9.12/binaries/apache-maven-3.9.12-bin.tar.gz --output apache-maven-3.9.12-bin.tar.gz
-RUN tar xzf apache-maven-3.9.12-bin.tar.gz
+RUN curl https://dlcdn.apache.org/maven/maven-3/3.9.16/binaries/apache-maven-3.9.16-bin.tar.gz --output apache-maven-3.9.16-bin.tar.gz
+RUN tar xzf apache-maven-3.9.16-bin.tar.gz
 COPY src ./src
 COPY pom.xml .
-RUN ./apache-maven-3.9.12/bin/mvn package -Pnative
+RUN ./apache-maven-3.9.16/bin/mvn package -Pnative
 
 # strip the binary
 FROM ubuntu AS stripper


### PR DESCRIPTION
I upgraded maven version used to build the 3 graalvm runtimes.
The previous version does not exist anymore, so the build failed and the overall workflow was broken since may 29.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.