### PR TITLE
bump: github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,10 @@
 version: 2
 updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+
   # app
   - package-ecosystem: "cargo"
     directory: "common_lib"

--- a/.github/workflows/aws-deploy.yml
+++ b/.github/workflows/aws-deploy.yml
@@ -19,8 +19,8 @@ jobs:
   deploy:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/cache@v3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.cargo/bin/
@@ -30,13 +30,13 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
       - name: Install Zig toolchain
-        uses: korandoru/setup-zig@v1
+        uses: korandoru/setup-zig@3d137e800ac114393177819328e565c3adc75210 # v1.7.1
         with:
           zig-version: 0.10.0
       - name: Install Cargo Lambda
-        uses: jaxxstorm/action-install-gh-release@v1.9.0
+        uses: jaxxstorm/action-install-gh-release@25e24d2d23ae098373794ef1d6faecb48ee52da8 # v3.0.0
         with:
           repo: cargo-lambda/cargo-lambda
           platform: linux
@@ -51,7 +51,7 @@ jobs:
       - name: install CDK
         run: sudo yarn global add aws-cdk
       - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-session-name: GitHub_Action_LambdaPerf_Session

--- a/.github/workflows/aws-deploy.yml
+++ b/.github/workflows/aws-deploy.yml
@@ -31,6 +31,8 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
+        with:
+          toolchain: stable
       - name: Install Zig toolchain
         uses: korandoru/setup-zig@3d137e800ac114393177819328e565c3adc75210 # v1.7.1
         with:

--- a/.github/workflows/push-to-ecr.yml
+++ b/.github/workflows/push-to-ecr.yml
@@ -45,7 +45,7 @@ jobs:
             echo "runner=ubuntu-24.04-arm" >> $GITHUB_OUTPUT
           fi
           cat $GITHUB_OUTPUT
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Build runtime matrix
         id: set-matrix
         run: |
@@ -60,9 +60,9 @@ jobs:
       matrix: 
         runtime_id: ${{fromJson(needs.setup.outputs.matrix)}}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
         with:
           role-to-assume: ${{ secrets.role }}
           role-session-name: GitHub_Action_LambdaPerf_Session
@@ -74,8 +74,8 @@ jobs:
           rm -rf /opt/ghc
           rm -rf "$AGENT_TOOLSDIRECTORY"
       - name: Set up Docker
-        uses: docker/setup-docker-action@v4
-      - uses: actions/setup-node@v4
+        uses: docker/setup-docker-action@0234bb73ccb40f0c430b795634f9247e2b5c2d23 # v5.2.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
       - name: build and deploy
@@ -94,7 +94,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
         with:
           role-to-assume: ${{ secrets.role }}
           role-session-name: GitHub_Action_LambdaPerf_Session

--- a/.github/workflows/push-to-s3.yml
+++ b/.github/workflows/push-to-s3.yml
@@ -42,7 +42,7 @@ jobs:
             echo "runner=ubuntu-24.04-arm" >> $GITHUB_OUTPUT
           fi
           cat $GITHUB_OUTPUT
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Build runtime matrix
         id: set-matrix
         run: |
@@ -58,23 +58,23 @@ jobs:
         runtime_id: ${{fromJson(needs.setup.outputs.matrix)}}
     steps:
       - name: configure aws credentials for DEV
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
         if: ${{ inputs.environment == 'DEV' }}
         with:
           role-to-assume: ${{ secrets.role }}
           role-session-name: GitHub_Action_LambdaPerf_Session_DEV
           aws-region: ${{ secrets.devRegion }}
       - name: configure aws credentials for PROD
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
         if: ${{ inputs.environment == 'PROD' }}
         with:
           role-to-assume: ${{ secrets.role }}
           role-session-name: GitHub_Action_LambdaPerf_Session_PROD
           aws-region: ${{ secrets.prodRegion }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Set up Docker
-        uses: docker/setup-docker-action@v4
-      - uses: actions/setup-node@v4
+        uses: docker/setup-docker-action@0234bb73ccb40f0c430b795634f9247e2b5c2d23 # v5.2.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
       - name: build and deploy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,8 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
+        with:
+          toolchain: stable
       - name: Install Zig toolchain
         uses: korandoru/setup-zig@3d137e800ac114393177819328e565c3adc75210 # v1.7.1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,15 +13,15 @@ jobs:
   test:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
       - name: Install Zig toolchain
-        uses: korandoru/setup-zig@v1
+        uses: korandoru/setup-zig@3d137e800ac114393177819328e565c3adc75210 # v1.7.1
         with:
           zig-version: 0.10.0
       - name: Install Cargo Lambda
-        uses: jaxxstorm/action-install-gh-release@v1.9.0
+        uses: jaxxstorm/action-install-gh-release@25e24d2d23ae098373794ef1d6faecb48ee52da8 # v3.0.0
         with:
           repo: cargo-lambda/cargo-lambda
           platform: linux


### PR DESCRIPTION
## Description

Pin all GitHub Actions to full commit SHAs for supply chain security, and add a monthly Dependabot schedule to keep them up to date.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.